### PR TITLE
set value on mutex in Unlock method

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -65,6 +65,15 @@ func (m *Mutex) Lock() error {
 
 // Unlock unlocks m and returns the status of unlock.
 func (m *Mutex) Unlock() bool {
+	// Set the mutex value for clients who only want to release a lock without
+	// having acquired it.
+	value, err := m.genValueFunc()
+	if err != nil {
+		return err
+	}
+
+	m.value = value
+
 	n := m.actOnPoolsAsync(func(pool Pool) bool {
 		return m.release(pool, m.value)
 	})


### PR DESCRIPTION
This would allow clients to release the lock even if they didn't acquire it in the first place, provided that they have `SetGenValueFunc` return the same value for a specific key.